### PR TITLE
Update admin participation vibes

### DIFF
--- a/impact-recreation-vibes/src/app/admin/admin.component.css
+++ b/impact-recreation-vibes/src/app/admin/admin.component.css
@@ -94,3 +94,33 @@ label {
   bottom: 8px;
   right: 8px;
 }
+
+.participation-card {
+  background-color: #fff;
+  padding: 16px;
+  border-radius: 8px;
+}
+
+.vibe-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.vibe-card {
+  background-color: #f0f0f0;
+  padding: 8px;
+  border-radius: 4px;
+  width: 180px;
+}
+
+.vibe-card.add-card {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.vibe-card.add-card button {
+  padding: 8px 12px;
+}

--- a/impact-recreation-vibes/src/app/admin/admin.component.html
+++ b/impact-recreation-vibes/src/app/admin/admin.component.html
@@ -2,7 +2,7 @@
   <nav class="tabs">
     <div class="tab" [class.active]="currentTab === 'setup'" (click)="currentTab = 'setup'">Program Set Up</div>
     <div class="tab" [class.active]="currentTab === 'quarter'" (click)="currentTab = 'quarter'">Quarter Close</div>
-    <div class="tab" [class.active]="currentTab === 'other'" (click)="currentTab = 'other'">Other</div>
+    <div class="tab" [class.active]="currentTab === 'participation'" (click)="currentTab = 'participation'">Participation Vibes</div>
   </nav>
 
   <div *ngIf="currentTab === 'setup'">
@@ -93,7 +93,19 @@
     </div>
   </div>
 
-  <div *ngIf="currentTab === 'other'" class="other-tab">
-    <p>Coming soon...</p>
+  <div *ngIf="currentTab === 'participation'" class="participation-tab">
+    <div class="participation-card">
+      <h3>Participation Vibe List</h3>
+      <div class="vibe-list">
+        <div class="vibe-card" *ngFor="let vibe of participationVibes">
+          <h4>{{ vibe.name }}</h4>
+          <p>Version: {{ vibe.version }}</p>
+          <p>Uploaded {{ vibe.uploadedDate }} by {{ vibe.uploadedBy }}</p>
+        </div>
+        <div class="vibe-card add-card">
+          <button (click)="addParticipationVibe()">Additional vibe +</button>
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/impact-recreation-vibes/src/app/admin/admin.component.ts
+++ b/impact-recreation-vibes/src/app/admin/admin.component.ts
@@ -43,13 +43,20 @@ interface Program {
   categories: Category[];
 }
 
+interface ParticipationVibe {
+  name: string;
+  version: string;
+  uploadedDate: string;
+  uploadedBy: string;
+}
+
 @Component({
   selector: 'app-admin',
   templateUrl: './admin.component.html',
   styleUrls: ['./admin.component.css']
 })
 export class AdminComponent {
-  currentTab: 'setup' | 'quarter' | 'other' = 'setup';
+  currentTab: 'setup' | 'quarter' | 'participation' = 'setup';
   lastLockdownDate: string | null = null;
   lastCloseDate: string | null = null;
   quarterAction: 'lockdown' | 'close' = 'lockdown';
@@ -95,6 +102,26 @@ export class AdminComponent {
           ]
         }
       ]
+    }
+  ];
+  participationVibes: ParticipationVibe[] = [
+    {
+      name: 'Super Goose Mode',
+      version: '1.0',
+      uploadedDate: '2023-09-01',
+      uploadedBy: 'AdminUser'
+    },
+    {
+      name: 'Feather Flair',
+      version: '1.1',
+      uploadedDate: '2023-09-10',
+      uploadedBy: 'VibeMaster'
+    },
+    {
+      name: 'Honker Harmony',
+      version: '2.0',
+      uploadedDate: '2023-09-15',
+      uploadedBy: 'GooseGuru'
     }
   ];
   selectedProgramIndex: number | null = null;
@@ -158,6 +185,15 @@ export class AdminComponent {
 
   selectSupplier(index: number) {
     this.selectedSupplierIndex = index;
+  }
+
+  addParticipationVibe() {
+    this.participationVibes.push({
+      name: 'New Vibe',
+      version: '1.0',
+      uploadedDate: new Date().toLocaleDateString(),
+      uploadedBy: 'You'
+    });
   }
 
   handleQuarterAction() {


### PR DESCRIPTION
## Summary
- rename Admin's 3rd tab to **Participation Vibes**
- display a sample Participation Vibe List with three sample entries
- add a blank card for adding new vibes
- style the participation vibe card layout
- keep a simple method for adding new vibe entries

## Testing
- `npm test` *(fails: ng not found)*