### PR TITLE
Update colors and admin defaults

### DIFF
--- a/impact-recreation-vibes/src/app/admin/admin.component.css
+++ b/impact-recreation-vibes/src/app/admin/admin.component.css
@@ -18,7 +18,7 @@
 }
 
 .tab.active {
-  background-color: purple;
+  background-color: #7f5eba;
   color: #fff;
 }
 
@@ -34,7 +34,7 @@
 .suppliers li {
   padding: 4px 0;
   cursor: pointer;
-  color: purple;
+  color: #7f5eba;
 }
 
 .selected {
@@ -53,7 +53,7 @@ label {
 }
 
 .count {
-  background-color: purple;
+  background-color: #7f5eba;
   color: #fff;
   border-radius: 12px;
   padding: 2px 6px;
@@ -69,7 +69,7 @@ label {
 
 .admin-page .categories h3,
 .admin-page .category-detail h4 {
-  background-color: orange;
+  background-color: #ff4e00;
 }
 
 .quarter-header {

--- a/impact-recreation-vibes/src/app/admin/admin.component.ts
+++ b/impact-recreation-vibes/src/app/admin/admin.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
 interface Supplier {
   name: string;
@@ -55,7 +55,7 @@ interface ParticipationVibe {
   templateUrl: './admin.component.html',
   styleUrls: ['./admin.component.css']
 })
-export class AdminComponent {
+export class AdminComponent implements OnInit {
   currentTab: 'setup' | 'quarter' | 'participation' = 'setup';
   lastLockdownDate: string | null = null;
   lastCloseDate: string | null = null;
@@ -128,6 +128,18 @@ export class AdminComponent {
   selectedCategoryIndex: number | null = null;
   selectedSupplierIndex: number | null = null;
 
+  ngOnInit() {
+    if (this.programs.length > 0) {
+      this.selectedProgramIndex = 0;
+      if (this.programs[0].categories.length > 0) {
+        this.selectedCategoryIndex = 0;
+        if (this.programs[0].categories[0].suppliers.length > 0) {
+          this.selectedSupplierIndex = 0;
+        }
+      }
+    }
+  }
+
   get selectedProgram(): Program | null {
     return this.selectedProgramIndex !== null ? this.programs[this.selectedProgramIndex] : null;
   }
@@ -157,8 +169,13 @@ export class AdminComponent {
 
   selectProgram(index: number) {
     this.selectedProgramIndex = index;
-    this.selectedCategoryIndex = null;
-    this.selectedSupplierIndex = null;
+    const program = this.selectedProgram;
+    if (program && program.categories.length > 0) {
+      this.selectCategory(0);
+    } else {
+      this.selectedCategoryIndex = null;
+      this.selectedSupplierIndex = null;
+    }
   }
 
   addCategory() {
@@ -172,7 +189,12 @@ export class AdminComponent {
 
   selectCategory(index: number) {
     this.selectedCategoryIndex = index;
-    this.selectedSupplierIndex = null;
+    const category = this.selectedCategory;
+    if (category && category.suppliers.length > 0) {
+      this.selectedSupplierIndex = 0;
+    } else {
+      this.selectedSupplierIndex = null;
+    }
   }
 
   addSupplier() {

--- a/impact-recreation-vibes/src/app/app.component.css
+++ b/impact-recreation-vibes/src/app/app.component.css
@@ -20,19 +20,20 @@
 }
 
 .brand {
-  color: orange;
+  color: #ff4e00;
   font-weight: bold;
   margin-right: 4px;
 }
 
 .quarter {
-  color: purple;
+  color: #7f5eba;
   margin-right: 4px;
 }
 
 .waffle {
-  color: orange;
+  color: #ff4e00;
   margin: 0 4px;
+  cursor: pointer;
 }
 
 .dropdown {
@@ -74,11 +75,12 @@
   padding: 10px 16px;
   background-color: #fff;
   border-top: 1px solid #ccc;
+  margin-top: auto;
 }
 
 .footer-left,
 .footer-right {
-  color: orange;
+  color: #ff4e00;
   font-weight: bold;
 }
 

--- a/impact-recreation-vibes/src/app/dashboard/dashboard.component.css
+++ b/impact-recreation-vibes/src/app/dashboard/dashboard.component.css
@@ -9,7 +9,7 @@
 
 .dashboard-title {
   margin-top: 0;
-  color: purple;
+  color: #7f5eba;
   font-size: 2rem;
   text-align: left;
 }
@@ -30,7 +30,7 @@
 
 .news-header,
 .entry-header {
-  background-color: purple;
+  background-color: #7f5eba;
   color: #fff;
   padding: 8px;
   border-radius: 4px;

--- a/impact-recreation-vibes/src/app/vibe-distribution/vibe-distribution.component.css
+++ b/impact-recreation-vibes/src/app/vibe-distribution/vibe-distribution.component.css
@@ -35,7 +35,7 @@
 }
 
 .tab.active {
-  background-color: purple;
+  background-color: #7f5eba;
   color: #fff;
 }
 

--- a/impact-recreation-vibes/src/app/vibe-management/vibe-management.component.css
+++ b/impact-recreation-vibes/src/app/vibe-management/vibe-management.component.css
@@ -50,7 +50,7 @@
 }
 
 .tab.active {
-  background-color: purple;
+  background-color: #7f5eba;
   color: #fff;
 }
 

--- a/impact-recreation-vibes/src/app/vibeidation-search/vibeidation-search.component.css
+++ b/impact-recreation-vibes/src/app/vibeidation-search/vibeidation-search.component.css
@@ -29,7 +29,7 @@
 }
 
 .tab.active {
-  background-color: purple;
+  background-color: #7f5eba;
   color: #fff;
 }
 

--- a/impact-recreation-vibes/src/styles.css
+++ b/impact-recreation-vibes/src/styles.css
@@ -6,7 +6,7 @@ body {
 
 /* Heading colors */
 h1, h2, h3, h4, h5 {
-  background-color: purple;
+  background-color: #7f5eba;
   color: #fff;
   padding: 4px;
   border-radius: 4px;


### PR DESCRIPTION
## Summary
- switch orange and purple theme colors to new hex codes
- make the footer stick to the bottom of the screen
- show a pointer cursor on the waffle menu
- auto-select the first program/category/supplier on the admin page

## Testing
- `npm test --silent` *(fails: ng not found)*